### PR TITLE
Update solr.md with jump-start instructions

### DIFF
--- a/docs-3.x/config/solr.md
+++ b/docs-3.x/config/solr.md
@@ -115,15 +115,15 @@ The `core` config value does not work for Solr 3.x or 4.x.
 
 You will almost certainly need to utilize your own custom Solr config. You can do that by telling Lando to inject solr config from a directory inside of your application.
 
-Consider a Drupal 8 application injecting the Solr 7.x config directly from the `search_api_solr` module as shown in the example below:
+Consider a Drupal 8 or 9 application injecting the Solr 7.x config directly from the `search_api_solr` module as shown in the example below:
 
 **A hypothetical project**
 
-Note that you can put your configuration files anywhere inside your application directory. We use a `config` directory but you can call it whatever you want such as `.lando` in the example below:
+Note that if using custom configuration you can put your configuration files anywhere inside your application directory. We use a `config` directory but you can call it whatever you want such as `.lando`. In this example we're using the ["jump-start" configuration](https://git.drupalcode.org/project/search_api_solr/-/tree/4.x/jump-start) from `search_api_solr`:
 
 ```bash
 ./
-|-- sites/all/modules/search_api_solr/solr-conf/7.x
+|-- web/modules/contrib/search_api_solr/jump-start/solr7/config-set
    |-- elevate.xml
    |-- mapping-ISOLatin1Accent.txt
    |-- protwords.txt
@@ -137,6 +137,7 @@ Note that you can put your configuration files anywhere inside your application 
    |-- solrcore.properties
    |-- stopwords.txt
    |-- synonyms.txt
+   |-- ... (and many more)
 |-- .lando.yml
 ```
 
@@ -147,7 +148,7 @@ services:
   myservice:
     type: solr
     config:
-      dir: sites/all/modules/search_api_solr/solr-conf/7.x
+      dir: web/modules/contrib/search_api_solr/jump-start/solr7/config-set
 ```
 
 ## Getting information


### PR DESCRIPTION
This updates the solr docs with updated paths (sites/all/modules isn't where most folks store their code anymore) and also points to the jump-start config now available in search_api_solr 4.x.

Co-authored-by: @froboy <froboy@gmail.com>