### PR TITLE
Fix vuepress config for docs repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,12 @@ node_modules
 env.yaml
 env.yml
 lando.env
+.lando.local.yml
 
 # Build dirs
 build
 dist
+_docs3
 
 # coverage reporting
 .nyc_output


### PR DESCRIPTION
While looking for the correct contribution link for the xdebug docs - which I will be updating in the next few days - I noticed that the configuration for vuepress does not match the new repo url!