### PR TITLE
Change SSH config section

### DIFF
--- a/docs-3.x/config/ssh.md
+++ b/docs-3.x/config/ssh.md
@@ -73,10 +73,9 @@ Setting this to a sufficiently large integer effectively disables the warning.
 
 ### Using a custom `ssh` config file
 
-If you want complete control over the `ssh` config Lando is using on your project, you should set `keys: false` and also inject a custom `ssh` config into the services that need it.
+Lando doesn't automatically forward the contents of your local ssh config. You can inject a custom `ssh` config into the services that need it.
 
 ```yaml
-keys: false
 services:
   appserver:
     overrides:
@@ -84,7 +83,7 @@ services:
         - ./config:/var/www/.ssh/config
 ```
 
-In the above `.lando.local.yml` example, we are disabling key loading for the project and using a custom `ssh` config for the service named `appserver`.
+In the above `.lando.local.yml` example, we are using a custom `ssh` config for the service named `appserver`.
 
 This assumes your custom file exists in the app root and is named `config`. Also note that you will want to mount at the _user_ `ssh` config location and not the _system_ level one. This file will, generally, live at `$HOME/.ssh/config` which resolves to `/var/www/.ssh/config` for many, but not all, Lando services.
 


### PR DESCRIPTION
As far as I can tell it's not necessary to set `keys: false` to load a custom config file. 

The `keys` directive appears to create a config file with a list of keys at `/etc/ssh/ssh_config`. Setting `keys:false` removes this list of imported keys rendering the config's list of hosts useless. 

The `services.appserver.overrides.volumes` directive maps a local config file to the lando user config, generally at `/var/www/.ssh/config`, which was otherwise an empty file, so there's no apparent conflict with `/etc/ssh/ssh_config`.

By leaving `keys` at its default value and setting  `services.appserver.overrides.volumes` to my custom config, I was able to both use my imported ssh keys and also import a custom list of ssh config host values. This allows me to do things like `ssh mycustomhostname` inside lando and get the expected results, which I need Lando to do during CI/CD on Github Actions. In short I needed both keys and config.