### PR TITLE
Update versions in Lando examples

### DIFF
--- a/getting-started/first-app.md
+++ b/getting-started/first-app.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to boot up and initialize your first project for usage with Lando with a Hello World!, Drupal 7 and Pantheon example.
+description: Learn how to boot up and initialize your first project for usage with Lando with a Hello World!, Drupal 9 and Pantheon example.
 next: ./updating.html
 prev: ./installation.html
 ---
@@ -40,30 +40,34 @@ open https://hello-lando.lndo.site
 lando destroy -y
 ```
 
-## Vanilla Drupal 7
+## Vanilla Drupal 9
 
 You can also pull in code from an external archive (or git repo/GitHub) to seed a new project.
 
 ```bash
 # Create a new directory for this example and enter it
-mkdir drupal7 && cd drupal7
+mkdir drupal9 && cd drupal9
 
-# Initialize a new lando drupal using vanilla d7
+# Initialize a new lando drupal using vanilla Drupal 9
 lando init \
   --source remote \
-  --remote-url https://ftp.drupal.org/files/projects/drupal-7.59.tar.gz \
+  --remote-url https://www.drupal.org/download-latest/tar.gz \
   --remote-options="--strip-components 1" \
-  --recipe drupal7 --webroot . \
-  --name hello-drupal7
+  --recipe drupal9 \
+  --webroot . \
+  --name hello-drupal9
 
 # Start the site
 lando start
 
-# Use the lando-provided drush to do a site install
-lando drush si --db-url=mysql://drupal7:drupal7@database/drupal7 -y
+# Install a site local drush
+lando composer require drush/drush
+
+# Install drupal
+lando drush site:install --db-url=mysql://drupal9:drupal9@database/drupal9 -y
 
 # Check out your new site!
-open https://hello-drupal7.lndo.site
+open https://hello-drupal9.lndo.site
 
 # Destroy it
 lando destroy -y

--- a/getting-started/what-it-do.md
+++ b/getting-started/what-it-do.md
@@ -67,7 +67,7 @@ If you are interested in using something Lando does not currently offer as a ser
 
 **[events](https://docs.lando.dev/config/events.html)** - Events allow the user to run arbitrary commands, or combinations of commands, on arbitrary services, or combinations of services before or after certain parts of the Lando runtime. A good example is clearing out an application's cache after a database is imported.
 
-**[recipe](https://docs.lando.dev/config/recipes.html)** - Recipes are combinations of [services](https://docs.lando.dev/config/services.html), [proxies](https://docs.lando.dev/config/proxy.html), and [tooling](https://docs.lando.dev/config/tooling.html) designed as a start-state-of-sane-defaults for a particular use case - e.g. `drupal7`.
+**[recipe](https://docs.lando.dev/config/recipes.html)** - Recipes are combinations of [services](https://docs.lando.dev/config/services.html), [proxies](https://docs.lando.dev/config/proxy.html), and [tooling](https://docs.lando.dev/config/tooling.html) designed as a start-state-of-sane-defaults for a particular use case - e.g. `drupal9`.
 
 **[config](https://docs.lando.dev/config/recipes.html#configuration)** - Config allows you to set some of the more important things your recipe provides. These settings are usually different depending on the recipe you select.
 
@@ -101,17 +101,17 @@ You can check out our [large repository of tested-every-build and working exampl
 
 ```yaml
 name: my-app
-recipe: drupal7
+recipe: drupal9
 ```
 
 ### Lighting the match
 
 ```yaml
 name: my-app
-recipe: drupal7
+recipe: drupal9
 config:
   database: postgres
-  php: '7.0'
+  php: '8.1'
   xdebug: true
 ```
 
@@ -119,10 +119,10 @@ config:
 
 ```yaml
 name: my-app
-recipe: drupal7
+recipe: drupal9
 config:
-  database: postgres
-  php: '7.0'
+  database: 'mysql:8.0'
+  php: '8.1'
   xdebug: true
   config:
     php: my-custom-php.ini
@@ -131,7 +131,7 @@ proxy:
    - pma-my-app.lndo.site
 services:
   node:
-    type: node:10
+    type: node:17
     globals:
       gulp: latest
   pma:
@@ -147,10 +147,10 @@ tooling:
 
 ```yaml
 name: my-app
-recipe: drupal7
+recipe: drupal9
 config:
-  database: postgres
-  php: '7.0'
+  php: '8.1'
+  database: 'mysql:8.0'
   xdebug: true
   config:
     php: my-custom-php.ini
@@ -172,11 +172,11 @@ services:
         APP_LEVEL: dev
         TAYLOR: swift
   node:
-    type: node:10
+    type: node:17
     globals:
       gulp: latest
   frontend:
-    type: node:10
+    type: node:17
     command: yarn start
     build:
       - yarn


### PR DESCRIPTION
Update `drupal7` to `drupal9`, latest Node version, as well as to MySQL, since PhpMyAdmin doesn't work with PostgreSQL.