### PR TITLE
Clarify how where plugins are loaded, and how they can be set up for development

### DIFF
--- a/contrib/coder.md
+++ b/contrib/coder.md
@@ -103,7 +103,7 @@ In fact, almost all of Lando's core functionality is provided via plugins. This 
 
 ### Plugin Loading
 
-Lando will search any path listed in `lando.config.pluginDirs` and automatically load in any plugins that it finds. By default, these directories are the Lando source directory and `~/.lando/plugins` but note that these paths are configurable via the Lando [global config](./../config/config.md).
+Lando will search any directory listed in `lando.config.pluginDirs` and automatically load any plugins that it finds in those directories. By default, the directories include the Lando source directory and the `~/.lando/plugins` directory. Note that these directories are configurable via Lando [global config](./../config/config.md).
 
 In order for Lando to successfully identify and automatically load your plugin, you need to have a directory named after your plugin, e.g. `my-plugin`, in one of the directories mentioned above and your plugin needs to include an `index.js` at the root level.
 
@@ -115,7 +115,8 @@ Some examples are in order:
 
   |-- yourplugin  Your custom plugin folder.
   |-- @lando      Are you making a fix to an existing lando plugin? Then put
-                    the cloned plugin inside the @lando namespace.
+                    the cloned plugin inside the @lando namespace. The @ prefix
+                    indicates a namespace for plugins.
     |-- landoplugin  Your forked plugin goes here. ‡
 ```
 ‡ _It is perfectly fine to symlink the directory from `~/.lando/plugins/yourplugin` to your source code, should you prefer to keep your working code elsewhere._

--- a/contrib/coder.md
+++ b/contrib/coder.md
@@ -103,9 +103,9 @@ In fact, almost all of Lando's core functionality is provided via plugins. This 
 
 ### Plugin Loading
 
-Lando will search any directory listed in `lando.config.pluginDirs` and automatically load any plugins that it finds in those directories. By default, the directories include the Lando source directory and the `~/.lando/plugins` directory. Note that these directories are configurable via Lando [global config](./../config/config.md).
+Lando will search the directories listed in `lando.config.pluginDirs` and automatically load any plugins that it finds in those directories. By default, the directories include the Lando source directory and the `~/.lando/plugins` directory. Note that these directories are configurable via Lando [global config](./../config/config.md).
 
-In order for Lando to successfully identify and automatically load your plugin, you need to have a directory named after your plugin, e.g. `my-plugin`, in one of the directories mentioned above and your plugin needs to include an `index.js` at the root level.
+In order for Lando to successfully identify and automatically load your plugin, you need to have a directory named after your plugin, e.g. `my-plugin`, in one of the directories mentioned above, and your plugin needs to include an `index.js` at the root level.
 
 Some examples are in order:
 ```

--- a/contrib/coder.md
+++ b/contrib/coder.md
@@ -105,10 +105,10 @@ In fact, almost all of Lando's core functionality is provided via plugins. This 
 
 Lando will search any path listed in `lando.config.pluginDirs` and automatically load in any plugins that it finds. By default, these directories are the Lando source directory and `~/.lando/plugins` but note that these paths are configurable via the Lando [global config](./../config/config.md).
 
-In order for Lando to successfully identify and automatically load your plugin, you need to have a directory named after your plugin, e.g. `my-plugin`, in one of the directories mentioned above and it needs to include an `index.js`.
+In order for Lando to successfully identify and automatically load your plugin, you need to have a directory named after your plugin, e.g. `my-plugin`, in one of the directories mentioned above and your plugin needs to include an `index.js` at the root level.
 
 Some examples are in order:
-```bash
+```
 ~./lando
 |-- plugins       Create this directory if it doesn't already exist. Lando
                     will automatically load plugins in this directory ‡
@@ -118,7 +118,7 @@ Some examples are in order:
                     the cloned plugin inside the @lando namespace.
     |-- landoplugin  Your forked plugin goes here. ‡
 ```
-‡ _It is perfectly fine to symlink the directory from `~/.lando/plugins/yourplugin` to your source code, should you prefer to keep your working code elsewhere.__
+‡ _It is perfectly fine to symlink the directory from `~/.lando/plugins/yourplugin` to your source code, should you prefer to keep your working code elsewhere._
 
 If there are multiple occurrences of the same-named plugin, Lando will use the last one it finds. This means that `lando` will prioritize user plugins over core plugins by default. A plugin found in the last plugin directory listed in `lando.config.pluginDirs` will override any earlier plugins found.
 

--- a/contrib/coder.md
+++ b/contrib/coder.md
@@ -103,9 +103,24 @@ In fact, almost all of Lando's core functionality is provided via plugins. This 
 
 ### Plugin Loading
 
-Lando will search in the `plugins` directory for any path listed in `lando.config.pluginDirs` and automatically load in any plugins that it finds. By default, these directories are the Lando source directory and `~/.lando` but note that they are configurable via the Lando [global config](./../config/config.md). In order for Lando to successfully identify and automatically load your plugin, you need to have a directory named after your plugin, e.g. `my-plugin`, in one of the directories mentioned above and it needs to include an `index.js`.
+Lando will search any path listed in `lando.config.pluginDirs` and automatically load in any plugins that it finds. By default, these directories are the Lando source directory and `~/.lando/plugins` but note that these paths are configurable via the Lando [global config](./../config/config.md).
 
-If there are multiple occurrences of the same-named plugin, Lando will use the last one it finds. This means that `lando` will prioritize user plugins over core plugins by default.
+In order for Lando to successfully identify and automatically load your plugin, you need to have a directory named after your plugin, e.g. `my-plugin`, in one of the directories mentioned above and it needs to include an `index.js`.
+
+Some examples are in order:
+```bash
+~./lando
+|-- plugins       Create this directory if it doesn't already exist. Lando
+                    will automatically load plugins in this directory ‡
+
+  |-- yourplugin  Your custom plugin folder.
+  |-- @lando      Are you making a fix to an existing lando plugin? Then put
+                    the cloned plugin inside the @lando namespace.
+    |-- landoplugin  Your forked plugin goes here. ‡
+```
+‡ _It is perfectly fine to symlink the directory from `~/.lando/plugins/yourplugin` to your source code, should you prefer to keep your working code elsewhere.__
+
+If there are multiple occurrences of the same-named plugin, Lando will use the last one it finds. This means that `lando` will prioritize user plugins over core plugins by default. A plugin found in the last plugin directory listed in `lando.config.pluginDirs` will override any earlier plugins found.
 
 **A powerful corollary to this is that individual user apps can implement plugins that override or replace core plugin behavior.**
 


### PR DESCRIPTION
From a lando slack thread. 

@[apotek](https://app.slack.com/team/U0375KF80CS) I think it would also help if that paragraph showed an example of: 1) creating and placing your plugin, both to override an existing plugin, and one that is a new one, and 2) Some ~/.lando/config.yml examples. The file just contains a yml object in {} notation.

What do you think? Any one of these three suggestions would help make that paragraph more clear to a newbie. I really struggled with it yesterday, when it is actually so simple.

@[reynoldsalec](https://app.slack.com/team/U2YP6FC8N)  I love the idea of making that section more explicit in the docs; if you had an idea on it would appreciate a PR



[It is really really difficult to not put a link to that video tutorial in these docs](https://www.twitch.tv/videos/1425689833)