### PR TITLE
chore: use correct spelling for Xdebug

### DIFF
--- a/guides/lando-phpstorm.md
+++ b/guides/lando-phpstorm.md
@@ -41,7 +41,7 @@ services:
   appserver:
     overrides:
       environment:
-        # Support debugging CLI with XDEBUG.
+        # Support debugging CLI with Xdebug.
         PHP_IDE_CONFIG: "serverName=appserver"
         XDEBUG_SESSION_START: lando
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


**What is the current behavior?** (You can also link to an open issue here)
The comment for debugging CLI commands contains _XDEBUG_ (all caps).


**What is the new behavior (if this is a feature change)?**
The comment for debugging CLI commands now correctly contains _Xdebug_ just like the other occurrences of that term.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
None.