### PR TITLE
Change link at bottom of page

### DIFF
--- a/lando-101/lando-tooling.md
+++ b/lando-101/lando-tooling.md
@@ -61,4 +61,4 @@ Now all the developers on our team for the Lando 101 app can code sniff their co
 lando phpcs index.php
 ```
 
-Adding the `phpcs` command is simple, but just one example of the types of tooling you can add to your apps. To take a deep dive and learn more about Lando tooling read the [tooling docs page](/config/tooling.html).
+Adding the `phpcs` command is simple, but just one example of the types of tooling you can add to your apps. To take a deep dive and learn more about Lando tooling read the [tooling docs page](/core/v3/tooling.html).


### PR DESCRIPTION
The link as it currently exists will take the user to 'https://docs.lando.dev/config%2Ftooling.html' when just using the left mouse button, this leads to a 404 not found page. When opening as a new tab or window it will take the user to the correct page: https://docs.lando.dev/core/v3/tooling.html.

This update simply changes the link to always send the user to the correct page for more tooling information.