### PR TITLE
Fix a couple of linkrot issues

### DIFF
--- a/guides/access-by-other-devices.md
+++ b/guides/access-by-other-devices.md
@@ -23,7 +23,7 @@ You may want to use another device (e.g., a smartphone or tablet) to test your L
 
 ## lando share (Testing over the Internet)
 
-The fastest way to do this is to use the [lando share](./../basics/share.html) command.  This will provide you with a URL that you can use to access your app via the Internet.  You can close the connection at any time by pressing a key in the terminal on your local machine.
+The fastest way to do this is to use the [lando share](./../cli/share) command.  This will provide you with a URL that you can use to access your app via the Internet.  You can close the connection at any time by pressing a key in the terminal on your local machine.
 
 ## Changing the Bind
 

--- a/help/dns-rebind.md
+++ b/help/dns-rebind.md
@@ -4,7 +4,7 @@ description: Learn how to handle DNS Rebinding protection when using Lando for l
 
 # DNS Rebinding Protection
 
-If you are using [Lando proxying](./../config/proxy.md), which is enabled by default, some routers and firewalls may prevent Lando from properly routing `*.lndo.site` addresses to your application through [DNS Rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) protection. For example the `DD-WRT` router firmware enables this protection by default.
+If you are using [Lando proxying](./../core/v3/proxy), which is enabled by default, some routers and firewalls may prevent Lando from properly routing `*.lndo.site` addresses to your application through [DNS Rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) protection. For example the `DD-WRT` router firmware enables this protection by default.
 
 If you are seeing red URLs after you start your app and you are unable to look up the url DNS rebinding protection may be the cause. You can test this out using `nslookup`.
 


### PR DESCRIPTION
Looks like these pages have moved over time - noticed both yesterday:

- https://docs.lando.dev/cli/share.html (broken link, "The fastest way to do this is to use the [lando share](https://docs.lando.dev/basics/share.html) command" from https://docs.lando.dev/guides/access-by-other-devices.html)
- https://docs.lando.dev/core/v3/proxy.html (broken link, "If you are using [Lando proxying](https://docs.lando.dev/config/proxy.html)" from https://docs.lando.dev/help/dns-rebind.html)

I tried testing these locally with `lando dev` from the Docs repo Lando configuration, but I see only an empty Vite wrapper frame.

It could be good to add a link-checker to the docs repo pipeline?